### PR TITLE
Passes searches to Timdex

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,6 +1,7 @@
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms'; // <-- NgModel lives here
+import { HttpClientModule } from '@angular/common/http';
 
 import { AppComponent } from './app.component';
 import { ResultsComponent } from './results/results.component';
@@ -16,7 +17,8 @@ import { MessagesComponent } from './messages/messages.component';
   ],
   imports: [
     BrowserModule,
-    FormsModule
+    FormsModule,
+    HttpClientModule
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/src/app/result.service.ts
+++ b/src/app/result.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Observable, of } from 'rxjs';
-import { catchError, map, tap } from 'rxjs/operators';
+import { catchError, map, pluck, tap } from 'rxjs/operators';
 
 import { MessageService } from './message.service';
 
@@ -35,11 +35,9 @@ export class ResultService {
     this.log('Fetched search results for ' + string, 'success');
     return this.http.get<Result[]>(url)
       .pipe(
-        map(results => results),
-        tap(x => console.log('Received something from http:')),
-        tap(x => console.log(x)),
-        tap(_ => this.log(`Fetched ${_.length} results`, 'success')),
-        catchError(this.handleError<Result[]>('getResults', []))
+        tap(_ => this.log('Fetched results', 'success')),
+        pluck('results'),
+        // catchError(this.handleError<Result[]>('getResults', [])),
       );
   }
 

--- a/src/app/result.service.ts
+++ b/src/app/result.service.ts
@@ -1,5 +1,7 @@
 import { Injectable } from '@angular/core';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Observable, of } from 'rxjs';
+import { catchError, map, tap } from 'rxjs/operators';
 
 import { MessageService } from './message.service';
 
@@ -11,7 +13,10 @@ import { RESULTS } from './mock-results'; // <-- Mock results
 })
 export class ResultService {
 
+  private searchUrl = 'https://timdex.mit.edu/api/v1/search'; // URL to web api
+
   constructor(
+    private http: HttpClient,
     private messageService: MessageService
   ) { }
 
@@ -19,13 +24,35 @@ export class ResultService {
     return null;
   }
 
-  getResults(string): Observable<Result[]> {
+  /** GET results from Timdex */
+  getResults(string: string): Observable<Result[]> {
+    const url = `${this.searchUrl}?q=${string}`;
     console.log('Result Service getResults: search for ' + string);
     if (!string.length) {
-      this.messageService.add('ResultService: Cannot conduct a search for nothing...', 'warning');
+      this.log('Cannot conduct a search for nothing...', 'warning');
       return;
     }
-    this.messageService.add('ResultService: Fetched search results for ' + string, 'success');
-    return of(RESULTS);
+    this.log('Fetched search results for ' + string, 'success');
+    return this.http.get<Result[]>(url)
+      .pipe(
+        map(results => results.results),
+        tap(x => console.log(x)),
+        tap(_ => this.log(`Fetched ${_.length} results`, 'success')),
+        catchError(this.handleError<Result[]>('getResults', []))
+      );
+  }
+
+  private handleError<T>(operation = 'operation', result?: T) {
+    return (error: any): Observable<T> => {
+      console.error(error);
+
+      this.log(`${operation} failed: ${error.message}`, 'error');
+
+      return of(result as T);
+    };
+  }
+
+  private log(message: string, type: string) {
+    this.messageService.add(`ResultService: ${message}`, type);
   }
 }

--- a/src/app/result.service.ts
+++ b/src/app/result.service.ts
@@ -35,7 +35,8 @@ export class ResultService {
     this.log('Fetched search results for ' + string, 'success');
     return this.http.get<Result[]>(url)
       .pipe(
-        map(results => results.results),
+        map(results => results),
+        tap(x => console.log('Received something from http:')),
         tap(x => console.log(x)),
         tap(_ => this.log(`Fetched ${_.length} results`, 'success')),
         catchError(this.handleError<Result[]>('getResults', []))

--- a/src/app/results/results.component.html
+++ b/src/app/results/results.component.html
@@ -2,7 +2,7 @@
   <h2>Search results</h2>
   <ul>
     <li *ngFor="let result of results" class="wrap-result">
-      <h3><a href="{{ result.link }}">{{ result.title }}</a></h3>
+      <h3><a href="{{ result.source_link }}">{{ result.title }}</a></h3>
     </li>
   </ul>
 </div>

--- a/src/app/search/search.component.ts
+++ b/src/app/search/search.component.ts
@@ -39,6 +39,8 @@ export class SearchComponent implements OnInit {
     console.log('Conducting search for ' + string);
     this.resultService.getResults(string)
       .subscribe(results => this.results = results);
+    console.log('Received the following:');
+    console.log(this.results);
   }
 
 


### PR DESCRIPTION
This is f'ughly, but it works. Searches are passed off to Timdex, and returned under an Observable that plucks the results array out of the response object.

In order to get this done, I had to disable the ErrorHandling call (you can see it commented out) because the compiler was complaining about unexpected (or missing) fields. There may need to be a Response interface defined that constrains the overall response object - in addition to the existing Result interface that defines the structure of an individual search result. Or maybe the Result interface needs to be an array, as Jeremy has suggested.

The next steps would be to try passing a search to multiple search targets for an actual bento interface, but at this point I'm calling time on this investigation.